### PR TITLE
perf(MemoryCache): Add EntryOptions to MemoryCache

### DIFF
--- a/src/AspNetCore.Diagnostics.CachedHealthChecks/CacheableHealthCheckService.cs
+++ b/src/AspNetCore.Diagnostics.CachedHealthChecks/CacheableHealthCheckService.cs
@@ -340,7 +340,13 @@ namespace AspNetCore.Diagnostics.CachedHealthChecks
                 exception: exception,
                 data: data);
 
-            memoryCache.Set(cacheKey, entry, expiresAt);
+            var memoryCacheEntryOptions = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = expiresIn,
+                Size = System.Runtime.InteropServices.Marshal.SizeOf(entry)
+            };
+
+            memoryCache.Set(cacheKey, entry, memoryCacheEntryOptions);
 
             return entry;
         }


### PR DESCRIPTION
The InMemoryCache grows for ever unless it's limited.
For the sake of performance, following the docs:
https://docs.microsoft.com/en-us/aspnet/core/performance/caching/memory?v
iew=aspnetcore-3.1